### PR TITLE
changed the matrix multiplication in line 60 for better performance

### DIFF
--- a/capsnet.py
+++ b/capsnet.py
@@ -48,14 +48,14 @@ class DigitCaps(nn.Module):
         self.num_routes = num_routes
         self.num_capsules = num_capsules
 
-        self.W = nn.Parameter(torch.randn(1, num_routes, num_capsules, out_channels, in_channels))
+        self.W = nn.Parameter(torch.randn(num_routes, num_capsules, out_channels, in_channels))
 
     def forward(self, x):
         batch_size = x.size(0)
-        x = torch.stack([x] * self.num_capsules, dim=2).unsqueeze(4)
-
-        W = torch.cat([self.W] * batch_size, dim=0)
-        u_hat = torch.matmul(W, x)
+        u_hat = torch.stack([torch.stack(
+            [torch.matmul(self.W[:, j, :, :], x[i].unsqueeze(-1))
+             for j in range(self.num_capsules)], dim=1)
+            for i in range(batch_size)])
 
         b_ij = Variable(torch.zeros(1, self.num_routes, self.num_capsules, 1))
         if USE_CUDA:


### PR DESCRIPTION
Instead of creating the matrix W, a large matrix, I have calculated the matrix multiplication in an iterative way. So for batch size 100, the memory allocation has reduced from 562 MiB to 141 MiB